### PR TITLE
Add IMAP email polling infrastructure and tests

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,7 @@
+# Features
+
+## Feature 2: Email Polling
+
+The `software/email_poller.py` module monitors an IMAP inbox for new messages. Each retrieved email is passed as a raw `email.message.Message` object to a placeholder `process_message(msg)` function. Feature 3 will implement attachment extraction and further handling of this message object.
+
+This email polling relies on **Feature 1: Data Contract Definition** to interpret CSV attachments that will be parsed later in the pipeline. Any change to the CSV schema defined in Feature 1 may require updates to the polling workflow.

--- a/software/config.py
+++ b/software/config.py
@@ -1,4 +1,6 @@
 import csv
+import json
+import os
 
 
 sensordata = ['Name', 'Status','Error', 'Adresse']
@@ -12,3 +14,42 @@ with open('config.csv', 'w', newline='') as file:
 
 def add_sensor(name,status,error,adresse,nummer):
     data += {'Name': name, 'Status': status,'Error':error, 'Adresse': adresse},
+
+
+def load_imap_config(path: str = 'config_private/imap_config.json') -> dict:
+    """Load IMAP configuration from a JSON file.
+
+    The configuration must contain the following keys:
+    imap_host, imap_port, use_ssl, username, password,
+    mailbox, search_criteria.
+
+    Args:
+        path: Path to the JSON configuration file.
+
+    Returns:
+        A dictionary with the configuration values.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        KeyError: If any required keys are missing.
+    """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"IMAP config file not found: {path}")
+
+    with open(path, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+
+    required = [
+        'imap_host',
+        'imap_port',
+        'use_ssl',
+        'username',
+        'password',
+        'mailbox',
+        'search_criteria',
+    ]
+    missing = [key for key in required if key not in config]
+    if missing:
+        raise KeyError(f"Missing keys in IMAP config: {', '.join(missing)}")
+
+    return config

--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -1,0 +1,60 @@
+import imaplib
+import email
+from email.message import Message
+import time
+import os
+import logging
+
+from .config import load_imap_config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)-8s %(name)s %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger('email_poller')
+
+
+def process_message(msg: Message) -> None:
+    """Placeholder for processing email messages."""
+    logger.info('Processing message: %s', msg.get('Subject'))
+
+
+def poll_for_reports() -> None:
+    """Continuously poll an IMAP inbox for new reports."""
+    config = load_imap_config()
+    while True:
+        try:
+            logger.info('Connecting to %s:%s', config['imap_host'], config['imap_port'])
+            conn = imaplib.IMAP4_SSL(config['imap_host'], config['imap_port'])
+            try:
+                conn.login(config['username'], config['password'])
+                logger.info('Logged in as %s', config['username'])
+                conn.select(config['mailbox'])
+                logger.info('Mailbox selected: %s', config['mailbox'])
+                status, messages = conn.search(None, *config['search_criteria'])
+                if status != 'OK':
+                    logger.error('Search failed with status %s', status)
+                else:
+                    for msg_id in messages[0].split():
+                        status, data = conn.fetch(msg_id, '(RFC822)')
+                        if status != 'OK':
+                            logger.error('Failed to fetch message %s: %s', msg_id, status)
+                            continue
+                        msg = email.message_from_bytes(data[0][1])
+                        logger.info('Fetched message %s', msg_id)
+                        process_message(msg)
+                        conn.store(msg_id, '+FLAGS', '\\Seen')
+                        logger.info('Marked message %s as seen', msg_id)
+            finally:
+                conn.logout()
+                logger.info('Logged out')
+        except Exception as exc:
+            logger.error('Error while polling: %s', exc)
+        if os.environ.get('EMAIL_POLLER_RUN_ONCE') == '1':
+            break
+        time.sleep(60)
+
+
+if __name__ == '__main__':
+    poll_for_reports()

--- a/test_email_poller.py
+++ b/test_email_poller.py
@@ -1,0 +1,81 @@
+import os
+import unittest
+from unittest.mock import patch
+import email
+import imaplib
+
+from software import email_poller
+
+
+with open('tests/sample_report.eml', 'rb') as f:
+    SAMPLE_BYTES = f.read()
+    SAMPLE_MESSAGE = email.message_from_bytes(SAMPLE_BYTES)
+
+
+class MockIMAP4(imaplib.IMAP4_SSL):
+    login_calls = 0
+    seen_calls = 0
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.sent = False
+
+    def login(self, username, password):
+        MockIMAP4.login_calls += 1
+        return 'OK', [b'Logged in']
+
+    def select(self, mailbox):
+        return 'OK', [b'']
+
+    def search(self, charset, *criteria):
+        if not self.sent:
+            self.sent = True
+            return 'OK', [b'1']
+        return 'OK', [b'']
+
+    def fetch(self, msg_id, _):
+        return 'OK', [(b'1', SAMPLE_BYTES)]
+
+    def store(self, msg_id, flags, data):
+        MockIMAP4.seen_calls += 1
+        return 'OK', [b'']
+
+    def logout(self):
+        return 'OK', [b'']
+
+
+class EmailPollerTest(unittest.TestCase):
+    def test_poll_for_reports(self):
+        processed = {}
+
+        def fake_process(msg):
+            processed['called'] = True
+            # Optionally assert the message is same as sample
+            self.assertEqual(msg.get('Subject'), SAMPLE_MESSAGE.get('Subject'))
+
+        config = {
+            'imap_host': 'localhost',
+            'imap_port': 993,
+            'use_ssl': True,
+            'username': 'user',
+            'password': 'pass',
+            'mailbox': 'INBOX',
+            'search_criteria': ['UNSEEN'],
+        }
+
+        with patch('software.email_poller.load_imap_config', return_value=config), \
+             patch('imaplib.IMAP4_SSL', MockIMAP4), \
+             patch('software.email_poller.process_message', side_effect=fake_process), \
+             patch('software.email_poller.time.sleep', return_value=None):
+            os.environ['EMAIL_POLLER_RUN_ONCE'] = '1'
+            email_poller.poll_for_reports()
+            del os.environ['EMAIL_POLLER_RUN_ONCE']
+
+        self.assertEqual(MockIMAP4.login_calls, 1)
+        self.assertEqual(MockIMAP4.seen_calls, 1)
+        self.assertTrue(processed.get('called'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sample_report.eml
+++ b/tests/sample_report.eml
@@ -1,0 +1,8 @@
+From: reports@example.com
+To: user@example.com
+Subject: Sample Report
+Date: Wed, 1 Jan 2020 00:00:00 +0000
+Message-ID: <sample-report-1@example.com>
+Content-Type: text/plain; charset="utf-8"
+
+This is a sample report email for testing.


### PR DESCRIPTION
## Summary
- add configuration loader for IMAP credentials
- introduce email polling module with logging and placeholder processing
- document Feature 2 email polling and dependency on Feature 1
- test email polling against a mocked IMAP server

## Testing
- `python test_email_poller.py`


------
