### PR TITLE
Enable standalone execution of email_poller

### DIFF
--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -1,3 +1,8 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
 import imaplib
 import email
 from email.message import Message
@@ -5,7 +10,7 @@ import time
 import os
 import logging
 
-from .config import load_imap_config
+from software.config import load_imap_config
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary
- Ensure `software.email_poller` can be run directly by appending the project root to `sys.path`
- Replace relative config import with absolute `software.config`

## Testing
- `EMAIL_POLLER_RUN_ONCE=1 python -m software.email_poller`
- `EMAIL_POLLER_RUN_ONCE=1 python software/email_poller.py`
- `pytest -q`

------