### PR TITLE
Gracefully handle offline IMAP connection

### DIFF
--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -77,8 +77,12 @@ def poll_for_reports_once(max_per_cycle: int | None = None) -> list[tuple[int, s
     conn = None
     try:
         logger.info('Connecting to %s:%s', cfg["imap_host"], cfg["imap_port"])
-        conn = imaplib.IMAP4_SSL(cfg["imap_host"], cfg["imap_port"])
-        conn.login(cfg["username"], cfg["password"])
+        try:
+            conn = imaplib.IMAP4_SSL(cfg["imap_host"], cfg["imap_port"])
+            conn.login(cfg["username"], cfg["password"])
+        except (OSError, imaplib.IMAP4.error):
+            logger.warning("No internet connection – unable to poll emails")
+            return attachments
         logger.info('Logged in as %s', cfg["username"])
 
         conn.select(cfg["mailbox"])

--- a/test_email_poller.py
+++ b/test_email_poller.py
@@ -53,6 +53,7 @@ class EmailPollerTest(unittest.TestCase):
             processed['called'] = True
             # Optionally assert the message is same as sample
             self.assertEqual(msg.get('Subject'), SAMPLE_MESSAGE.get('Subject'))
+            return []
 
         config = {
             'imap_host': 'localhost',
@@ -68,13 +69,30 @@ class EmailPollerTest(unittest.TestCase):
              patch('imaplib.IMAP4_SSL', MockIMAP4), \
              patch('software.email_poller.process_message', side_effect=fake_process), \
              patch('software.email_poller.time.sleep', return_value=None):
-            os.environ['EMAIL_POLLER_RUN_ONCE'] = '1'
-            email_poller.poll_for_reports()
-            del os.environ['EMAIL_POLLER_RUN_ONCE']
+            email_poller.poll_for_reports_once()
 
         self.assertEqual(MockIMAP4.login_calls, 1)
         self.assertEqual(MockIMAP4.seen_calls, 1)
         self.assertTrue(processed.get('called'))
+
+    def test_poll_for_reports_no_internet(self):
+        config = {
+            'imap_host': 'localhost',
+            'imap_port': 993,
+            'use_ssl': True,
+            'username': 'user',
+            'password': 'pass',
+            'mailbox': 'INBOX',
+            'search_criteria': ['UNSEEN'],
+        }
+
+        with patch('software.email_poller.load_imap_config', return_value=config), \
+             patch('imaplib.IMAP4_SSL', side_effect=OSError('network down')), \
+             self.assertLogs('email_poller', level='WARNING') as cm:
+            result = email_poller.poll_for_reports_once()
+
+        self.assertEqual(result, [])
+        self.assertIn('No internet connection', cm.output[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Guard email polling against missing network by catching OSError/IMAP errors during connection and login
- Add regression tests for offline scenarios and fix existing poller test

## Testing
- `pytest -q`


------