### PR TITLE
Log processed files locally instead of using database table

### DIFF
--- a/software/db.py
+++ b/software/db.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, Tuple, List, Set
 
 import psycopg2
@@ -156,7 +157,13 @@ def insert_readings(rows: List[dict]) -> None:
 # ---------- processed files logging ----------
 
 def log_processed_file(archive_path: str, ingestion_date: datetime) -> None:
-    """Record a processed file and when it was ingested.
+    """Record a processed file locally with its ingestion timestamp.
+
+    Instead of storing this information in the database, append it to a
+    ``processed_files.log`` file in the project root. Each line contains the
+    ISO formatted ingestion time followed by the archive path, separated by a
+    comma. This allows tracking processed files without requiring any database
+    schema changes.
 
     Parameters
     ----------
@@ -166,14 +173,8 @@ def log_processed_file(archive_path: str, ingestion_date: datetime) -> None:
         When the file was ingested.
     """
 
-    sql = (
-        "INSERT INTO processed_files (archive_path, ingestion_date) VALUES (%s, %s)"
-    )
-    conn = get_conn()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(sql, (archive_path, ingestion_date))
-        conn.commit()
-        logger.info("Logged processed file %s", archive_path)
-    finally:
-        conn.close()
+    log_path = Path("processed_files.log")
+    line = f"{ingestion_date.isoformat()},{archive_path}\n"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+    logger.info("Logged processed file %s", archive_path)

--- a/tests/test_log_processed_file.py
+++ b/tests/test_log_processed_file.py
@@ -1,0 +1,28 @@
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Provide a minimal psycopg2 stub so db.py can be imported without the real dependency
+psycopg2 = types.ModuleType("psycopg2")
+psycopg2.connect = lambda *args, **kwargs: None
+extras = types.ModuleType("extras")
+extras.execute_values = lambda *args, **kwargs: None
+psycopg2.extras = extras
+sys.modules.setdefault("psycopg2", psycopg2)
+sys.modules.setdefault("psycopg2.extras", extras)
+
+from software.db import log_processed_file
+
+
+def test_log_processed_file_writes_entry(tmp_path, monkeypatch):
+    # Run in a temporary directory to avoid polluting repository root
+    monkeypatch.chdir(tmp_path)
+    archive_path = "archive/some_file.csv"
+    ts = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    log_processed_file(archive_path, ts)
+
+    log_file = Path("processed_files.log")
+    assert log_file.exists()
+    assert log_file.read_text() == f"{ts.isoformat()},{archive_path}\n"


### PR DESCRIPTION
## Summary
- Record processed CSV file paths and ingestion timestamps in a local `processed_files.log`
- Add regression test ensuring log file entries are written correctly

## Testing
- `pytest -q`


------
