### PR TITLE
Persist email poller errors and run continuously

### DIFF
--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -17,6 +17,11 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger('email_poller')
+# Persist errors to file for later inspection
+error_handler = logging.FileHandler('email_errors.log')
+error_handler.setLevel(logging.ERROR)
+error_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
+logger.addHandler(error_handler)
 
 
 def process_message(msg: Message):
@@ -147,7 +152,27 @@ def poll_for_reports_once(max_per_cycle: int | None = None) -> list[tuple[int, s
                 pass
 
 
+def run_forever():
+    """Continuously poll for reports, pausing on errors or empty cycles."""
+    while True:
+        try:
+            attachments = poll_for_reports_once()
+            if attachments:
+                logger.info("Saved %d attachment file(s) this run", len(attachments))
+                continue
+        except Exception:
+            logger.exception("Poller failure")
+
+        logger.info("retrying in 15 minutes")
+        next_attempt = time.time() + 15 * 60
+        logger.info("Next attempt at %s", time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(next_attempt)))
+        while True:
+            remaining = int(next_attempt - time.time())
+            if remaining <= 0:
+                break
+            logger.info("Next attempt in %d seconds", remaining)
+            time.sleep(min(60, remaining))
+
+
 if __name__ == '__main__':
-    # Optional: loop forever if you ever want a daemon mode
-    files = poll_for_reports_once()
-    logger.info("Saved %d attachment file(s) this run", len(files))
+    run_forever()


### PR DESCRIPTION
## Summary
- log poller failures to `email_errors.log`
- add `run_forever` to continually poll and handle retries

## Testing
- `pytest -q`


------
