### PR TITLE
feat: centralize logging configuration

### DIFF
--- a/software/csv_parser.py
+++ b/software/csv_parser.py
@@ -4,12 +4,6 @@ from datetime import datetime, timezone
 import logging
 
 logger = logging.getLogger("csv_parser")
-if not logger.handlers:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
 
 def parse_csv(rp_id: int, filepath: str):
     """

--- a/software/db.py
+++ b/software/db.py
@@ -9,12 +9,6 @@ import psycopg2
 from psycopg2.extras import execute_values
 
 logger = logging.getLogger("db")
-if not logger.handlers:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
 
 # ---------- config / connection ----------
 

--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -11,11 +11,6 @@ import logging
 
 from software.config import load_imap_config
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)-8s %(name)s %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
 logger = logging.getLogger('email_poller')
 
 

--- a/software/logging_setup.py
+++ b/software/logging_setup.py
@@ -1,0 +1,45 @@
+import os
+import logging
+import logging.config
+from logging.handlers import RotatingFileHandler
+
+
+def setup_logging() -> None:
+    """Configure application-wide logging.
+
+    Creates a ``logs`` directory and configures both console and rotating file
+    handlers writing to ``logs/app.log``. The log format and level are consistent
+    across handlers.
+    """
+    os.makedirs("logs", exist_ok=True)
+
+    logging_config = {
+        "version": 1,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s %(levelname)-8s %(name)s %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "level": "INFO",
+            },
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "standard",
+                "level": "INFO",
+                "filename": "logs/app.log",
+                "maxBytes": 10 * 1024 * 1024,
+                "backupCount": 5,
+            },
+        },
+        "root": {
+            "handlers": ["console", "file"],
+            "level": "INFO",
+        },
+    }
+
+    logging.config.dictConfig(logging_config)

--- a/software/main_ingest.py
+++ b/software/main_ingest.py
@@ -4,6 +4,10 @@ import logging
 from datetime import datetime, timezone
 from typing import Dict, Tuple
 
+from software.logging_setup import setup_logging
+
+setup_logging()
+
 from software.email_poller import poll_for_reports_once
 from software.csv_parser import parse_csv
 from software.db import (
@@ -13,11 +17,6 @@ from software.db import (
     ensure_sensors,      # FK safety
 )
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 logger = logging.getLogger("main_ingest")
 
 EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)


### PR DESCRIPTION
## Summary
- add `setup_logging()` helper configuring console and rotating file logging
- invoke `setup_logging()` at startup of `main_ingest` for consistent logs
- remove scattered `logging.basicConfig` calls from modules

## Testing
- `pytest -q`


------
