### PR TITLE
Centralize logging and add rotating error logs

### DIFF
--- a/software/archiver.py
+++ b/software/archiver.py
@@ -1,0 +1,29 @@
+"""Utility functions for archiving processed files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime, timezone
+import shutil
+
+
+def archive_with_date(file_path: str) -> Path:
+    """Move *file_path* into the ``archive`` directory with a timestamped name.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the file that should be archived.
+
+    Returns
+    -------
+    Path
+        The destination path of the archived file.
+    """
+    src = Path(file_path)
+    archive_dir = Path("archive")
+    archive_dir.mkdir(exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    dest = archive_dir / f"{src.stem}_{timestamp}{src.suffix}"
+    shutil.move(str(src), dest)
+    return dest

--- a/software/csv_parser.py
+++ b/software/csv_parser.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timezone
 import logging
 
-logger = logging.getLogger("csv_parser")
+logger = logging.getLogger(__name__)
 
 def parse_csv(rp_id: int, filepath: str):
     """

--- a/software/db.py
+++ b/software/db.py
@@ -8,7 +8,7 @@ from typing import Dict, Tuple, List, Set
 import psycopg2
 from psycopg2.extras import execute_values
 
-logger = logging.getLogger("db")
+logger = logging.getLogger(__name__)
 
 # ---------- config / connection ----------
 

--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -11,17 +11,7 @@ import logging
 
 from software.config import load_imap_config
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)-8s %(name)s %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
-logger = logging.getLogger('email_poller')
-# Persist errors to file for later inspection
-error_handler = logging.FileHandler('email_errors.log')
-error_handler.setLevel(logging.ERROR)
-error_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
-logger.addHandler(error_handler)
+logger = logging.getLogger(__name__)
 
 
 def process_message(msg: Message):
@@ -175,4 +165,7 @@ def run_forever():
 
 
 if __name__ == '__main__':
+    from software.logging_setup import setup_logging
+
+    setup_logging()
     run_forever()

--- a/software/logging_setup.py
+++ b/software/logging_setup.py
@@ -35,9 +35,17 @@ def setup_logging() -> None:
                 "maxBytes": 10 * 1024 * 1024,
                 "backupCount": 5,
             },
+            "errors": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "standard",
+                "level": "ERROR",
+                "filename": "logs/errors.log",
+                "maxBytes": 10 * 1024 * 1024,
+                "backupCount": 5,
+            },
         },
         "root": {
-            "handlers": ["console", "file"],
+            "handlers": ["console", "file", "errors"],
             "level": "INFO",
         },
     }

--- a/software/main_ingest.py
+++ b/software/main_ingest.py
@@ -16,23 +16,7 @@ from software.db import (
 )
 from software.archiver import archive_with_date
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-logger = logging.getLogger("main_ingest")
-
-# Separate file handler to capture only errors
-error_handler = logging.FileHandler("ingest_errors.log")
-error_handler.setLevel(logging.ERROR)
-error_handler.setFormatter(
-    logging.Formatter(
-        "%(asctime)s %(levelname)-8s %(name)s %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-)
-logger.addHandler(error_handler)
+logger = logging.getLogger(__name__)
 
 EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
 CHUNK_SIZE = 50_000  # tweak for your DB/network
@@ -122,4 +106,7 @@ def run_forever() -> None:
 
 
 if __name__ == "__main__":
+    from software.logging_setup import setup_logging
+
+    setup_logging()
     run_forever()

--- a/test_email_poller.py
+++ b/test_email_poller.py
@@ -88,7 +88,7 @@ class EmailPollerTest(unittest.TestCase):
 
         with patch('software.email_poller.load_imap_config', return_value=config), \
              patch('imaplib.IMAP4_SSL', side_effect=OSError('network down')), \
-             self.assertLogs('email_poller', level='WARNING') as cm:
+             self.assertLogs('software.email_poller', level='WARNING') as cm:
             result = email_poller.poll_for_reports_once()
 
         self.assertEqual(result, [])


### PR DESCRIPTION
## Summary
- centralize logging with rotating app and error handlers
- use module-level loggers and setup_logging in ingest and poller scripts
- add utility to archive processed files with timestamp

## Testing
- `pytest`


------
