### PR TITLE
Add main entry points and document logging requirements

### DIFF
--- a/software/email_poller.py
+++ b/software/email_poller.py
@@ -143,7 +143,13 @@ def poll_for_reports_once(max_per_cycle: int | None = None) -> list[tuple[int, s
 
 
 def run_forever():
-    """Continuously poll for reports, pausing on errors or empty cycles."""
+    """Continuously poll for reports, pausing on errors or empty cycles.
+
+    This function assumes that logging has already been configured by the
+    caller. In command-line use, :func:`software.logging_setup.setup_logging`
+    should be invoked before calling :func:`run_forever`, or callers may set up
+    logging themselves.
+    """
     while True:
         try:
             attachments = poll_for_reports_once()
@@ -164,8 +170,12 @@ def run_forever():
             time.sleep(min(60, remaining))
 
 
-if __name__ == '__main__':
+def main() -> None:
     from software.logging_setup import setup_logging
 
     setup_logging()
     run_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/software/main_ingest.py
+++ b/software/main_ingest.py
@@ -28,6 +28,12 @@ def _sleep_with_countdown(minutes: int = 15) -> None:
 
 
 def run_forever() -> None:
+    """Ingest downloaded CSV reports in a continuous loop.
+
+    Logging must be configured by the caller prior to invoking this function,
+    e.g. via :func:`software.logging_setup.setup_logging` or by setting up
+    logging in another manner.
+    """
     os.makedirs("archive", exist_ok=True)
 
     while True:
@@ -100,8 +106,12 @@ def run_forever() -> None:
             _sleep_with_countdown()
 
 
-if __name__ == "__main__":
+def main() -> None:
     from software.logging_setup import setup_logging
 
     setup_logging()
     run_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `main()` helpers in `email_poller` and `main_ingest` to configure logging before running
- document that `run_forever()` requires logging setup

## Testing
- `pytest -q`


------
